### PR TITLE
Reduce Q-Learning agent memory requirements

### DIFF
--- a/brain/agent/ql.py
+++ b/brain/agent/ql.py
@@ -1,3 +1,11 @@
+"""
+Q-Learning agent for Dark Chess with memory optimizations.
+
+Memory Optimizations:
+- State keys stored as bytes instead of tuples: ~93% reduction (88.7 GB -> 6.1 GB for 100M states)
+- Q-values stored as float16 instead of float32: 50% reduction (131.1 GB -> 65.6 GB for 100M states)
+- Total memory reduction: ~67% (219.8 GB -> 71.6 GB for 100M states)
+"""
 import ast
 import copy
 import random
@@ -50,8 +58,11 @@ class QL(BaseAgent, LearningBaseAgent):
         }
 
         # Initialize Q-table with zeros
-        self.q_table: DefaultDict[Tuple[int], np.ndarray] = defaultdict(
-            lambda: np.zeros(len(self.action2idx), dtype=np.float32)
+        # Use bytes as keys instead of tuples for memory efficiency
+        # bytes: 32 bytes per state vs tuples: ~896 bytes per state (32 * 28 bytes per Python int)
+        # Use float16 instead of float32 to reduce Q-value memory by 50%
+        self.q_table: DefaultDict[bytes, np.ndarray] = defaultdict(
+            lambda: np.zeros(len(self.action2idx), dtype=np.float16)
         )
 
         # Reward structure for chess and game results
@@ -83,11 +94,12 @@ class QL(BaseAgent, LearningBaseAgent):
         max_q = np.max(q_vals)
         return self.idx2action[avail_idx[random.choice([i for i, q in enumerate(q_vals) if q == max_q])]]
 
-    def _get_state_key(self, board: List[str], color: Literal[1, -1]) -> Tuple[int]:
+    def _get_state_key(self, board: List[str], color: Literal[1, -1]) -> bytes:
         # Viewed as the black side board
+        # Convert to bytes for memory efficiency (1 byte per position vs 28 bytes per Python int)
         if color == -1:
-            return tuple(self.chess2idx_color_reverse[code] for code in board)
-        return tuple(self.chess2idx[code] for code in board)
+            return bytes(self.chess2idx_color_reverse[code] for code in board)
+        return bytes(self.chess2idx[code] for code in board)
 
     def _model_eval(self, switch: bool = False) -> None:
         self.eval_epsilon = 0.0 if switch else self.epsilon
@@ -337,7 +349,8 @@ class QL(BaseAgent, LearningBaseAgent):
 
     def save_to_local(self, path: str) -> None:
         raw = dict(self.q_table)
-        states = np.array([str(s) for s in raw.keys()], dtype=str)
+        # Store states as 2D array of uint8 for memory efficiency
+        states = np.array([list(s) for s in raw.keys()], dtype=np.uint8)
         q_values = np.stack(list(raw.values()), axis=0)
         np.savez_compressed(path, states=states, q_values=q_values)
 
@@ -345,12 +358,27 @@ class QL(BaseAgent, LearningBaseAgent):
         data = np.load(path, allow_pickle=False)
         states_arr = data["states"]
         q_values   = data["q_values"]
-        raw_loaded = {
-            ast.literal_eval(states_arr[i]): q_values[i]
-            for i in range(len(states_arr))
-        }
+        
+        # Convert Q-values to float16 if they're not already
+        if q_values.dtype != np.float16:
+            q_values = q_values.astype(np.float16)
+        
+        # Handle both old format (strings) and new format (uint8 arrays)
+        if states_arr.dtype.kind == 'U' or states_arr.dtype.kind == 'S':
+            # Old format: string representation of tuples
+            raw_loaded = {
+                bytes(ast.literal_eval(str(states_arr[i]))): q_values[i]
+                for i in range(len(states_arr))
+            }
+        else:
+            # New format: uint8 arrays
+            raw_loaded = {
+                bytes(states_arr[i]): q_values[i]
+                for i in range(len(states_arr))
+            }
+        
         self.q_table = defaultdict(
-            lambda: np.zeros(len(self.action2idx), dtype=np.float32),
+            lambda: np.zeros(len(self.action2idx), dtype=np.float16),
             raw_loaded
         )
 


### PR DESCRIPTION
## Problem

The Q-Learning agent was consuming approximately **200GB of RAM** during training with 100M states, making it impractical to train on most systems. This memory usage stemmed from two inefficiencies:

1. **State keys stored as Python tuples**: Each tuple of 32 integers consumed ~952 bytes per state due to Python object overhead
2. **Q-values stored as float32**: Each state's 352 Q-values consumed 1,408 bytes

## Solution

This PR implements two targeted memory optimizations to `brain/agent/ql.py`:

### 1. State Key Optimization: tuple → bytes (93% reduction)

Changed state representation from Python tuples to native bytes objects:

```python
# Before
state_key = tuple(self.chess2idx[code] for code in board)  # ~952 bytes
self.q_table: DefaultDict[Tuple[int], np.ndarray] = ...

# After  
state_key = bytes(self.chess2idx[code] for code in board)  # ~65 bytes
self.q_table: DefaultDict[bytes, np.ndarray] = ...
```

**Savings**: 88.7 GB → 6.1 GB for 100M states

### 2. Q-Value Optimization: float32 → float16 (50% reduction)

Changed Q-value storage from 32-bit to 16-bit floating point:

```python
# Before
lambda: np.zeros(len(self.action2idx), dtype=np.float32)  # 1,408 bytes

# After
lambda: np.zeros(len(self.action2idx), dtype=np.float16)  # 704 bytes
```

**Savings**: 131.1 GB → 65.6 GB for 100M states

See https://github.com/JacobLinCool/darkchess-robot/pull/1 for details